### PR TITLE
Update test workflow in respect to go get deprecation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Download dependencies
       run: |
-        go get .
+        go install .
         go install golang.org/x/vuln/cmd/govulncheck@latest
 
     - name: Run tests


### PR DESCRIPTION
Hello! I encountered an error telling me that go get is depreciated. I solved this in my own project by changing the "go get ." line to "go install ."

Docs: https://go.dev/doc/go-get-install-deprecation